### PR TITLE
Fix a typo endd -> end for sfloat section

### DIFF
--- a/Documentation/Compiler.tex
+++ b/Documentation/Compiler.tex
@@ -971,7 +971,7 @@ You can change the default sizes for \verb|sfloat| values using the commands.
     sfloat.plen=5 
     sfloat.vlen=10
     sfloat.kappa=20
-\endd{mylisting}
+\end{mylisting}
 The default values being $8$, $24$ and $40$ respectively.
 
 The $\err$ flag needs to be treated with some care.

--- a/Documentation/Installation.tex
+++ b/Documentation/Installation.tex
@@ -28,7 +28,7 @@ the main repository in your \verb+$HOME+ directory.
     cd ${mylocal}
 
     # install MPIR 3.0.0
-    curl -O 'http://mpir.org/mpir-3.0.0.tar.bz2'
+    curl -O http://mpir.org/mpir-3.0.0.tar.bz2
     tar xf mpir-3.0.0.tar.bz2
     cd mpir-3.0.0
     ./configure --enable-cxx --prefix="${mylocal}/mpir"


### PR DESCRIPTION
Thanks to Nigel and your students for making this documentation 
-- it is also valuable for people using MP-SPDZ.