### PR TITLE
Added root-level .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,16 @@
+# Custom Configuration
+CONFIG.mine
+
+# Test Logs
+Scripts/logs
+
+# MAMBA Compilation Products
+Programs/**
+!Programs/**/*.mpc
+
+# Build Prodcuts
+src/**/*.o
+Setup.x
+Player.x
+src/libMPC.a
+


### PR DESCRIPTION
Added a gitignore file to prevent compilation outputs (of both the framework and MAMBA programs), test logs and custom configuration from showing up in git.