### PR TITLE
Fixed a DEBUG compilation error in Processor.h

### DIFF
--- a/src/Processor/Processor.h
+++ b/src/Processor/Processor.h
@@ -246,7 +246,7 @@ public:
 
   void write_daBit(int i1, int j1)
   {
-    daBitV.get_daBit(temp.Sansp, temp.aB, daBitGen);
+    daBitV.get_daBit(temp.Sansp, temp.aB, *daBitGen);
     rwp[i1 + reg_maxp]= 1;
     rwsb[j1]= 1;
     Sp.at(i1)= temp.Sansp;


### PR DESCRIPTION
When switching on the DEBUG flag, conditional code failed to compile due to conflicting pointer vs reference usage.