### PR TITLE
Consistent checking for success of filestream open.

### DIFF
--- a/src/GC/Base_Circuits.cpp
+++ b/src/GC/Base_Circuits.cpp
@@ -15,46 +15,50 @@ All rights reserved
 /* This it the global store of circuits */
 Base_Circuits Global_Circuit_Store;
 
-void Base_Circuits::initialize(const bigint &p)
+Circuit Base_Circuits::load_circuit(const string &path)
 {
+  ifstream inpf;
   Circuit C;
 
-  ifstream inpf;
-
-  inpf.open("Circuits/Bristol/adder64.txt");
+  inpf.open(path);
+  if (inpf.fail())
+    throw file_error(path);
   inpf >> C;
   inpf.close();
-  Circuits.insert(make_pair(0, C));
 
-  inpf.open("Circuits/Bristol/sub64.txt");
-  inpf >> C;
-  inpf.close();
-  Circuits.insert(make_pair(1, C));
+  return C;
+}
 
-  inpf.open("Circuits/Bristol/mult2_64.txt");
-  inpf >> C;
-  inpf.close();
-  Circuits.insert(make_pair(2, C));
+void Base_Circuits::initialize(const bigint &p)
+{
 
-  inpf.open("Circuits/Bristol/mult64.txt");
-  inpf >> C;
-  inpf.close();
-  Circuits.insert(make_pair(3, C));
+  Circuits.insert(make_pair(
+    0, load_circuit("Circuits/Bristol/adder64.txt")
+  ));
 
-  inpf.open("Circuits/Bristol/divide64.txt");
-  inpf >> C;
-  inpf.close();
-  Circuits.insert(make_pair(4, C));
+  Circuits.insert(make_pair(
+    1, load_circuit("Circuits/Bristol/sub64.txt")
+  ));
 
-  inpf.open("Circuits/Bristol/neg64.txt");
-  inpf >> C;
-  inpf.close();
-  Circuits.insert(make_pair(5, C));
+  Circuits.insert(make_pair(
+    2, load_circuit("Circuits/Bristol/mult2_64.txt")
+  ));
 
-  inpf.open("Circuits/Bristol/zero_equal.txt");
-  inpf >> C;
-  inpf.close();
-  Circuits.insert(make_pair(6, C));
+  Circuits.insert(make_pair(
+    3, load_circuit("Circuits/Bristol/mult64.txt")
+  ));
+
+  Circuits.insert(make_pair(
+    4, load_circuit("Circuits/Bristol/divide64.txt")
+  ));
+
+  Circuits.insert(make_pair(
+    5, load_circuit("Circuits/Bristol/neg64.txt")
+  ));
+
+  Circuits.insert(make_pair(
+    6, load_circuit("Circuits/Bristol/zero_equal.txt")
+  ));
 
   /* We can do a conversion if log_2 p bits mod p 
    * give something statistically close to random mod p
@@ -79,10 +83,9 @@ void Base_Circuits::initialize(const bigint &p)
   if (lg2p > sreg_bitl &&
       ((lg2p > sreg_bitl + conv_stat_sec) || (y1 > conv_stat_sec) || (y2 > conv_stat_sec)))
     {
-      inpf.open("Data/ConversionCircuit-LSSS_to_GC.txt");
-      inpf >> C;
-      inpf.close();
-      Circuits.insert(make_pair(7, C));
+      Circuits.insert(make_pair(
+        7, load_circuit("Data/ConversionCircuit-LSSS_to_GC.txt")
+      ));
 
       convert_ok= true;
     }
@@ -120,11 +123,9 @@ void Base_Circuits::check(int num)
     {
       loaded[num]= true;
 
-      Circuit C;
-      ifstream inpf(location[num]);
-      inpf >> C;
-      inpf.close();
-      Circuits.insert(make_pair(num, C));
+      Circuits.insert(make_pair(
+        num, load_circuit(location[num])
+      ));
     }
   mutex_GC_load.unlock();
 }

--- a/src/GC/Base_Circuits.h
+++ b/src/GC/Base_Circuits.h
@@ -58,6 +58,8 @@ public:
 
   bool convert_ok; // Signals whether we can do GC <-> LSSS conversion or not
 
+  static Circuit load_circuit(const string &path);
+
   void initialize(const bigint &p);
 
   // Checks if the indirect circuit is loaded, it not it loads it */

--- a/src/GC/Circuit.cpp
+++ b/src/GC/Circuit.cpp
@@ -26,6 +26,8 @@ unsigned int cnt_numI(const GateType &T)
 
 istream &operator>>(istream &s, Circuit &C)
 {
+  if (s.fail())
+    throw std::invalid_argument("the given istream instance is in a failure state!");
   unsigned int nG, te;
   s >> nG >> C.nWires;
 

--- a/src/Player.cpp
+++ b/src/Player.cpp
@@ -313,6 +313,10 @@ int main(int argc, const char *argv[])
       stringstream ss;
       ss << "Data/FHE-Key-" << my_number << ".key";
       inp.open(ss.str().c_str());
+      if (inp.fail())
+        {
+          throw file_error(ss.str());
+        }
       bigint p0, p1, pr;
       unsigned int hwt, N;
       inp >> N >> p0 >> p1 >> pr >> hwt;

--- a/src/Setup.cpp
+++ b/src/Setup.cpp
@@ -90,6 +90,11 @@ void init_FHE(bigint &pr, int lg2p, unsigned int n)
       stringstream ss;
       ss << "Data/FHE-Key-" << i << ".key";
       ofstream outk(ss.str().c_str());
+      if (outk.fail())
+        {
+          cout << "Could not open output file " << ss.str() << endl;
+          exit(1);
+        }
       sk.assign(si[i]);
       outk << N << " " << p0 << " " << p1 << " " << pr << " " << hwt << endl
            << ":";
@@ -107,6 +112,11 @@ void init_certs()
   // SSL_CTX *ctx = InitServerCTX();
 
   ofstream output("Data/NetworkData.txt");
+  if (output.fail())
+    {
+      cout << "Could not open output file Data/NetworkData.txt." << endl;
+      exit(1);
+    }
 
   cout << "Enter the name of the root CA (e.g. RootCA)" << endl;
   string CAName;
@@ -114,6 +124,11 @@ void init_certs()
 
   string str= "Cert-Store/" + CAName + ".crt";
   ifstream cert_file(str);
+  if (cert_file.fail())
+    {
+      cout << "Could not open certificate file " << str << " ." << endl;
+      exit(1);
+    }
   stringstream cert_buff;
   cert_buff << cert_file.rdbuf();
   cout << "Cert is\n"
@@ -157,6 +172,11 @@ void init_certs()
       output << str << " ";
       str= "Cert-Store/" + str;
       ifstream player_cert_file(str);
+      if (player_cert_file.fail())
+        {
+          cout << "Could not open certificate file " << str << endl;
+          exit(1);
+        }
       stringstream player_cert_buff;
       player_cert_buff << player_cert_file.rdbuf();
       cout << "Cert is\n"
@@ -357,6 +377,12 @@ void init_Q2_MSP(ShareData &SD, unsigned int n)
 void init_secret_sharing()
 {
   ifstream input("Data/NetworkData.txt");
+  if (input.fail())
+    {
+      cout << "Could not open Data/NetworkData.txt.\n"
+          << "Make sure to run setup phase 1." << endl;
+      exit(1);
+    }
   string str;
   input >> str;
   unsigned int n;
@@ -447,6 +473,11 @@ void init_secret_sharing()
     }
 
   ofstream out("Data/SharingData.txt");
+  if (out.fail())
+    {
+      cout << "Could not open output file Data/SharingData.txt." << endl;
+      exit(1);
+    }
   out << p << endl;
   out << SD;
   out.close();
@@ -458,6 +489,11 @@ void init_secret_sharing()
       stringstream ss;
       ss << "Data/MKey-" << i << ".key";
       ofstream outk(ss.str().c_str());
+      if (outk.fail())
+        {
+          cout << "Cout not open output file " << ss.str() << endl;
+          exit(1);
+        }
       for (unsigned int j= 0; j < SD.nmacs; j++)
         {
           gfp aa;
@@ -476,6 +512,12 @@ void init_conversion()
 {
   bigint p;
   ifstream inpf("Data/SharingData.txt");
+  if (inpf.fail())
+    {
+      cout << "Could not open Data/SharingData.txt.\n"
+          << "Make sure to run setup phase 2." << endl;
+      exit(1);
+    }
   inpf >> p;
   inpf.close();
 
@@ -510,6 +552,11 @@ void init_conversion()
   cout << "Producing conversion circuit LSSS to GC for prime " << p << endl;
   // Now load the 512 bit adder
   inpf.open("Circuits/Bristol/LSSS_to_GC.txt");
+  if (inpf.fail())
+    {
+      cout << "Could not open Circuits/Bristol/LSSS_to_GC.txt. Make sure the file is available." << endl;
+      exit(1);
+    }
   inpf >> C512;
   inpf.close();
 
@@ -560,6 +607,11 @@ void init_conversion()
   CSub= CC.Get_Circuit();
 
   outf.open("Data/ConversionCircuit-LSSS_to_GC.txt");
+  if (outf.fail())
+    {
+      cout << "Could not open conversion circuit output file (ConversionCircuit-LSSS_to_GC.txt)." << endl;
+      exit(1);
+    }
   outf << CSub << endl;
   outf.close();
 


### PR DESCRIPTION
Previously, filestreams were not checked for failure state
after opening a file, which lead to undefined behaviour if an
opened file did not exist: Feeding such a failure-state stream
into Circuit lead to overallocation of memory and crashes (e.g.).

Now all filestream open calls are checked for success and exit
immediately with an error message if the stream is in failure state.