### PR TITLE
No longer compiling debug symbols by default

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,96 @@
+# Offline data, runtime logs #
+##############################
+logs/*
+
+# Ignore files without extension
+*
+!*/
+!*.*
+
+# Personal CONFIG file #
+##############################
+CONFIG.mine
+config_mine.py
+
+# Temporary files #
+###################
+*.bak
+*.orig
+*.rej
+*.tmp
+callgrind.out.*
+
+# Vim
+.*.swp
+tags
+
+# Eclipse #
+###########
+.project
+.cproject
+.settings
+
+# VS Code IDE #
+###############
+.vscode/**
+
+# Temporary files #
+###################
+*.bak
+*.orig
+*.rej
+*.tmp
+callgrind.out.*
+
+# Compiled source #
+###################
+Programs/*/*.sch
+Programs/*/*.bc
+*.com
+*.class
+*.dll
+*.exe
+*.x
+*.o
+*.so
+*.pyc
+*.bc
+*.sch
+*.a
+*.static
+*.d
+
+# Packages #
+############
+# it's better to unpack these files and commit the raw source
+# git has its own built in compression methods
+*.7z
+*.dmg
+*.gz
+*.iso
+*.jar
+*.rar
+*.tar
+*.zip
+
+# Latex #
+#########
+*.aux
+*.lof
+*.log
+*.lot
+*.fls
+*.out
+*.toc
+*.fmt
+*.bbl
+*.bcf
+*.blg
+
+
+# Logs and databases #
+######################
+*.log
+*.sql
+*.sqlite
+*.data

--- a/CONFIG
+++ b/CONFIG
@@ -5,6 +5,7 @@ OSSL = /users/cosic/nsmart/local/openssl/
 #   SH_DEBUG = Share debugging (for development only)
 #   DEBUG = Checks for reads before writes on register access
 #   DETERMINISTIC = Removes all randomness, gain for debugging
+#   -g = Causes the compiler to include debugging symbols
 
 # MAX_MOD = 7 should be OK for 128 bit based FHE operations
 MAX_MOD = 7
@@ -13,7 +14,7 @@ MAX_MOD = 7
 #   BENCH_NETDATA = Enable benchmarking of network data
 #   BENCH_MEMORY  = Enable benchmarking of memory 
 
-#FLAGS = -DSH_DEBUG -DDEBUG -DMAX_MOD_SZ=$(MAX_MOD) -DDETERMINISTIC -DBENCH_NETDATA -DBENCH_MEMORY
+#FLAGS = -DSH_DEBUG -DDEBUG -DMAX_MOD_SZ=$(MAX_MOD) -DDETERMINISTIC -DBENCH_NETDATA -DBENCH_MEMORY -g
 FLAGS = -DMAX_MOD_SZ=$(MAX_MOD) 
 
 OPT = -O3 

--- a/CONFIG
+++ b/CONFIG
@@ -14,9 +14,12 @@ MAX_MOD = 7
 #   BENCH_NETDATA = Enable benchmarking of network data
 #   BENCH_MEMORY  = Enable benchmarking of memory 
 
-#FLAGS = -DSH_DEBUG -DDEBUG -DMAX_MOD_SZ=$(MAX_MOD) -DDETERMINISTIC -DBENCH_NETDATA -DBENCH_MEMORY -g
-FLAGS = -DMAX_MOD_SZ=$(MAX_MOD) 
+# # example debug config
+# FLAGS = -g -DSH_DEBUG -DDEBUG -DMAX_MOD_SZ=$(MAX_MOD) -DDETERMINISTIC -DBENCH_NETDATA -DBENCH_MEMORY
+# OPT = -O0
 
+# example release config
+FLAGS = -DMAX_MOD_SZ=$(MAX_MOD) 
 OPT = -O3 
 
 LDFLAGS = 

--- a/Circuits/Makefile
+++ b/Circuits/Makefile
@@ -2,7 +2,7 @@ include ../CONFIG.mine
 
 CC = g++
 
-CFLAGS = -Wall -std=c++11 -pedantic -Wextra -g -pthread -I$(ROOT)/src -maes -mpclmul -msse4.1 -march=core2 $(FLAGS) $(OPT)
+CFLAGS = -Wall -std=c++11 -pedantic -Wextra -pthread -I$(ROOT)/src -maes -mpclmul -msse4.1 -march=core2 $(FLAGS) $(OPT)
 CPPFLAGS = $(CFLAGS) 
 LDLIBS = -L/$(OSSL)/lib -lm -lssl -lcrypto -lmpirxx -lmpir -lcryptopp $(LDFLAGS)
 

--- a/README.md
+++ b/README.md
@@ -40,13 +40,17 @@ want to maintain stability between releases for people using the
 system. Thus we have created the following rules of thumb:
 
 i)   New releases will be about every quarter.
+
 ii)  Only major bug fixes will be done in the mean time.
+
 iii) Join the mailing list to get updates (spdz@googlegroups.com)
+
 iv)  For small changes/bug fixes you find, either email the group
      or make a pull request here. We will then look at the code,
      integrate it into our private master system and perform the
      testing on it. Then we will push to GitHub with the next
      release.
+
 v)   Major changes (more than the odd line here or there), please
      talk  with us first. You may be doing something which we
      plan to scrap in the near future. So you dont want to waste

--- a/README.md
+++ b/README.md
@@ -32,3 +32,23 @@ to check all is OK.
 If you want to recompile the `.net` circuits from the `.vhd` see the
 instructions in Circuits/README.txt
 
+# Contributing and Releases
+
+We run a quite extensive test suite on all changes to the system.
+Indeed the testing takes around three days on our machines. We also
+want to maintain stability between releases for people using the
+system. Thus we have created the following rules of thumb:
+
+i)   New releases will be about every quarter.
+ii)  Only major bug fixes will be done in the mean time.
+iii) Join the mailing list to get updates (spdz@googlegroups.com)
+iv)  For small changes/bug fixes you find, either email the group
+     or make a pull request here. We will then look at the code,
+     integrate it into our private master system and perform the
+     testing on it. Then we will push to GitHub with the next
+     release.
+v)   Major changes (more than the odd line here or there), please
+     talk  with us first. You may be doing something which we
+     plan to scrap in the near future. So you dont want to waste
+     your time. 
+

--- a/Test/Makefile
+++ b/Test/Makefile
@@ -3,7 +3,7 @@ include ../CONFIG.mine
 
 CC = g++
 
-CFLAGS = -Wall -std=c++11 -pedantic -Wextra -g -pthread -I$(ROOT)/src -maes -mpclmul -msse4.1 -march=core2 $(FLAGS) $(OPT)
+CFLAGS = -Wall -std=c++11 -pedantic -Wextra -pthread -I$(ROOT)/src -maes -mpclmul -msse4.1 -march=core2 $(FLAGS) $(OPT)
 CPPFLAGS = $(CFLAGS) 
 LDLIBS = -L/$(OSSL)/lib -lm -lssl -lcrypto -lmpirxx -lmpir -lcryptopp $(LDFLAGS)
 

--- a/src/Exceptions/handler.cpp
+++ b/src/Exceptions/handler.cpp
@@ -16,6 +16,7 @@ All rights reserved
 #include <iostream>
 using namespace std;
 
+#ifdef DEBUG
 void error_handler()
 {
   void *array[50];
@@ -87,3 +88,9 @@ void error_handler()
 
   free(messages);
 }
+#else
+void error_handler()
+{
+  ;
+}
+#endif

--- a/src/Makefile
+++ b/src/Makefile
@@ -3,7 +3,7 @@ include ../CONFIG.mine
 
 CC = g++
 
-CFLAGS = -Wall -std=c++11 -pedantic -Wextra -g -pthread -I$(ROOT)/src -maes -mpclmul -msse4.1 -mavx -march=core2 $(FLAGS) $(OPT) -I$(OSSL)/include
+CFLAGS = -Wall -std=c++11 -pedantic -Wextra -pthread -I$(ROOT)/src -maes -mpclmul -msse4.1 -mavx -march=core2 $(FLAGS) $(OPT) -I$(OSSL)/include
 CPPFLAGS = $(CFLAGS) 
 LDLIBS = -L/$(OSSL)/lib -lm -lssl -lcrypto -lmpirxx -lmpir -lcryptopp $(LDFLAGS)
 

--- a/src/Processor/Processor.h
+++ b/src/Processor/Processor.h
@@ -246,7 +246,7 @@ public:
 
   void write_daBit(int i1, int j1)
   {
-    daBitV.get_daBit(temp.Sansp, temp.aB, daBitGen);
+    daBitV.get_daBit(temp.Sansp, temp.aB, *daBitGen);
     rwp[i1 + reg_maxp]= 1;
     rwsb[j1]= 1;
     Sp.at(i1)= temp.Sansp;


### PR DESCRIPTION
.. to drastically reduce compiled file size.
(removed -g flag from CFLAGS in Makefiles)

Users who want to compile with debug symbols
may append -g to FLAGS in CONFIG.mine...

note to maintainers: this is a suggestion that I believe makes sense for a production level system but of course you'll have to decide whether to go with it or not