### PR TITLE
Efficiency tweak for src/Makefile

### DIFF
--- a/Test/Makefile
+++ b/Test/Makefile
@@ -11,41 +11,14 @@ all: Test.x Test-FHE.x Test-Adv-FHE.x Test-Circuit.x FHE-P.x Test-Simplify.x Tes
 
 LIB = ../src/libMPC.a
 
-OBJ =  Test.o Test-FHE.o Test-Adv-FHE.o Test-Circuit.o FHE-P.o Test-Simplify.o Test-Convert.o 
 
-SRC = Test.cpp Test-FHE.cpp Test-Adv-FHE.cpp Test-Circuit.cpp FHE-P.cpp Test-Simplify.cpp Test-Convert.cpp 
+.PRECIOUS: %.o
+%.o: %.cpp
+	$(CC) $(CFLAGS) -o $@ -c $< 
 
-$(OBJ): $(SRC)
-	$(CC) $(CFLAGS) -c $*.cpp
-
-Test.x: $(OBJ) 
-	$(CC) $(CFLAGS) -o Test.x Test.o $(LIB) $(LDLIBS)
-	- mv Test.x ../
-
-Test-FHE.x: $(OBJ) 
-	$(CC) $(CFLAGS) -o Test-FHE.x Test-FHE.o $(LIB) $(LDLIBS)
-	- mv Test-FHE.x ../
-
-Test-Adv-FHE.x: $(OBJ)
-	$(CC) $(CFLAGS) -o Test-Adv-FHE.x Test-Adv-FHE.o $(LIB) $(LDLIBS)
-	- mv Test-Adv-FHE.x ../
-
-FHE-P.x: $(OBJ)
-	$(CC) $(CFLAGS) -o FHE-P.x FHE-P.o $(LIB) $(LDLIBS)
-	- mv FHE-P.x ../
-
-
-Test-Circuit.x: $(OBJ)
-	$(CC) $(CFLAGS) -o Test-Circuit.x Test-Circuit.o $(LIB) $(LDLIBS)
-	- mv Test-Circuit.x ../
-
-Test-Simplify.x: $(OBJ)
-	$(CC) $(CFLAGS) -o Test-Simplify.x Test-Simplify.o $(LIB) $(LDLIBS)
-	- mv Test-Simplify.x ../
-
-Test-Convert.x: $(OBJ)
-	$(CC) $(CFLAGS) -o Test-Convert.x Test-Convert.o $(LIB) $(LDLIBS)
-	- mv Test-Convert.x ../
+%.x: %.o
+	$(CC) $(CFLAGS) -o $@ $< $(LIB) $(LDLIBS)
+	- mv $@ ../
 
 clean:
 	- rm *.o 

--- a/src/Makefile
+++ b/src/Makefile
@@ -25,24 +25,17 @@ EXCEPTIONS = $(patsubst %.cpp,%.o,$(wildcard Exceptions/*.cpp))
 
 LIB = libMPC.a
 
-OBJ = Setup.o Player.o 
-
-SRC = Setup.cpp Player.cpp 
-
 %.o: %.cpp
 	$(CC) $(CFLAGS) -o $@ -c $< 
-
-$(OBJ): $(SRC)
-	$(CC) $(CFLAGS) -c $*.cpp
 
 $(LIB): $(SYSTEM) $(MATH) $(TOOLS) $(LSSS) $(OFFLINE) $(ONLINE) $(OT) $(PROCESSOR) $(IO) $(FHE) $(GC) $(LOCAL_FUNC) $(EXCEPTIONS)
 	$(AR) -crs libMPC.a $^
 
-Setup.x: $(OBJ) $(LIB)
+Setup.x: Setup.o $(LIB)
 	$(CC) $(CFLAGS) -o Setup.x Setup.o $(LIB) $(LDLIBS)
 	- mv Setup.x ../
 
-Player.x: $(OBJ) $(LIB)
+Player.x: Player.o $(LIB)
 	$(CC) $(CFLAGS) -o Player.x Player.o $(LIB) $(LDLIBS)
 	- mv Player.x ../
 


### PR DESCRIPTION
The Makefiles were written such that changes to either
one source file always caused both all executables
to be recompiled. This is now fixed.