### PR TITLE
Allowing for parallel builds

### DIFF
--- a/Circuits/Makefile
+++ b/Circuits/Makefile
@@ -15,5 +15,5 @@ all:
 
 clean:
 	-rm *.x
-	-cd VHDL; make clean
+	-cd VHDL; $(MAKE) clean
 

--- a/Circuits/VHDL/Makefile
+++ b/Circuits/VHDL/Makefile
@@ -10,6 +10,6 @@ clean:
 	-rm ARCH/*
 	-rm ENTI/*
 	-rm alib-52/*
-	-cd COSIC/SHA-3 ; make clean
-	-cd COSIC/AES ; make clean
+	-cd COSIC/SHA-3 ; $(MAKE) clean
+	-cd COSIC/AES ; $(MAKE) clean
 

--- a/Makefile
+++ b/Makefile
@@ -1,35 +1,35 @@
 all: 
-	make progs
-	make test
-	make doc
+	$(MAKE) progs
+	$(MAKE) test
+	$(MAKE) doc
 
 progs:
-	-cd src ; make
+	-cd src ; $(MAKE)
 
 test:
-	-cd Test ; make
+	-cd Test ; $(MAKE)
 
 doc: 
-	-cd Documentation ; make
+	-cd Documentation ; $(MAKE)
 	-cd Compiler ; doxygen doxy.config
 
 circuits:
-	-cd Circuits ; make ; ./convert.sh
+	-cd Circuits ; $(MAKE) ; ./convert.sh
 
 clean:
 	-rm  *.x
-	-cd src ; make clean
-	-cd Test ; make clean
-	-cd Circuits ; make clean 
+	-cd src ; $(MAKE) clean
+	-cd Test ; $(MAKE) clean
+	-cd Circuits ; $(MAKE) clean 
 
 pclean:
 	-cd Programs ; rm */*.bc ; rm */*.sch
 	-cd Scripts ; rm -r logs
 
 vclean:
-	- make clean
-	- make pclean
-	- cd Documentation ; make clean
+	- $(MAKE) clean
+	- $(MAKE) pclean
+	- cd Documentation ; $(MAKE) clean
 
 format:
 	- clang-format -i */*.cpp


### PR DESCRIPTION
replaced all recursive invocations of make by $(MAKE)
according to recommended practice (which allows
make to build in parallel with the -j N command line arg)

see also: https://stackoverflow.com/questions/50510278/makefile-why-always-use-make-instead-of-make