### PR TITLE
Create Input_Output_File for handling file I/O

### DIFF
--- a/src/Input_Output/Input_Output_File.cpp
+++ b/src/Input_Output/Input_Output_File.cpp
@@ -1,0 +1,223 @@
+/*
+Copyright (c) 2017, The University of Bristol, Senate House, Tyndall Avenue, Bristol, BS8 1TH, United Kingdom.
+Copyright (c) 2018, COSIC-KU Leuven, Kasteelpark Arenberg 10, bus 2452, B-3001 Leuven-Heverlee, Belgium.
+
+All rights reserved
+*/
+
+#include <iostream>
+#include <memory>
+#include <sstream>
+#include <string>
+
+#include "Input_Output_File.h"
+#include "Exceptions/Exceptions.h"
+
+std::string Input_Output_File::open_channel_filename_helper(
+    unsigned int channel,
+    const std::string& fn) {
+  std::stringstream s;
+  s << _datadir << "/" << fn << "_" << channel << ".txt";
+  return std::move(s.str());
+}
+
+long Input_Output_File::open_channel(unsigned int channel) {
+  *_outf << "Player " << _player_number << " Opening Channel "
+        << channel << std::endl;
+
+  // Private GFP IO
+  auto private_infile_gfp_name =
+      open_channel_filename_helper(channel, "private_input_gfp");
+  *_outf << "Private GFP Infile=" << private_infile_gfp_name << std::endl;
+
+  auto private_outfile_gfp_name =
+      open_channel_filename_helper(channel, "private_output_gfp");
+  *_outf << "Private GFP Outfile=" << private_outfile_gfp_name << std::endl;
+
+  _private_gfp_ifiles[channel] =
+    std::make_unique<std::ifstream>(private_infile_gfp_name);
+  _private_gfp_ofiles[channel] =
+    std::make_unique<std::ofstream>(private_outfile_gfp_name);
+
+  //this snippet always sets the fail bit to zero on file open
+  // so we don't fail immediately if a file doesn't exist
+  // get state
+  auto private_gfp_state = _private_gfp_ifiles[channel]->rdstate();
+  // remove failbit from it
+  private_gfp_state &= ~std::ifstream::failbit;
+  // clear old state and set new state
+  _private_gfp_ifiles[channel]->clear(private_gfp_state);
+
+  // these force exceptions if there is a problem with the file stream
+  _private_gfp_ifiles[channel]->exceptions(std::ifstream::failbit);
+  _private_gfp_ofiles[channel]->exceptions(std::ofstream::failbit);
+
+
+  // Public GFP IO
+  auto public_infile_gfp_name =
+      open_channel_filename_helper(channel, "public_input_gfp");
+  *_outf << "Public GFP Infile=" << public_infile_gfp_name << std::endl;
+
+  auto public_outfile_gfp_name =
+      open_channel_filename_helper(channel, "public_output_gfp");
+  *_outf << "Public GFP Outfile=" << public_outfile_gfp_name << std::endl;
+
+  _public_gfp_ifiles[channel] =
+    std::make_unique<std::ifstream>(public_infile_gfp_name);
+  _public_gfp_ofiles[channel] =
+    std::make_unique<std::ofstream>(public_outfile_gfp_name);
+
+  // get state
+  auto public_gfp_state = _public_gfp_ifiles[channel]->rdstate();
+  // remove failbit from it
+  public_gfp_state &= ~std::ifstream::failbit;
+  // clear old state and set new state
+  _public_gfp_ifiles[channel]->clear(public_gfp_state);
+
+  _public_gfp_ifiles[channel]->exceptions(std::ifstream::failbit);
+  _public_gfp_ofiles[channel]->exceptions(std::ofstream::failbit);
+
+
+  // Public Int IO
+  auto public_infile_int_name =
+      open_channel_filename_helper(channel, "public_input_int");
+  *_outf << "Public Int Infile=" << public_infile_int_name << std::endl;
+
+  auto public_outfile_int_name =
+      open_channel_filename_helper(channel, "public_output_int");
+  *_outf << "Public Int Outfile=" << public_outfile_int_name << std::endl;
+
+  _public_int_ifiles[channel] =
+      std::make_unique<std::ifstream>(public_infile_int_name);
+  _public_int_ofiles[channel] =
+      std::make_unique<std::ofstream>(public_outfile_int_name);
+
+  // get state
+  auto public_int_state = _public_int_ifiles[channel]->rdstate();
+  // remove failbit from it
+  public_int_state &= ~std::ifstream::failbit;
+  // clear old state and set new state
+  _public_int_ifiles[channel]->clear(public_int_state);
+
+  _public_int_ifiles[channel]->exceptions(std::ifstream::failbit);
+  _public_int_ofiles[channel]->exceptions(std::ofstream::failbit);
+
+  // Share IO
+  auto share_infile_name = open_channel_filename_helper(channel, "share_input");
+  *_outf << "Share Infile=" << share_infile_name << std::endl;
+
+  auto share_outfile_name = open_channel_filename_helper(channel, "share_output");
+  *_outf << "Share Outfile=" << share_outfile_name << std::endl;
+
+  _share_ifiles[channel] = std::make_unique<std::ifstream>(share_infile_name);
+  _share_ofiles[channel] = std::make_unique<std::ofstream>(share_outfile_name);
+
+  // get state
+  auto share_state = _share_ifiles[channel]->rdstate();
+  // remove failbit from it
+  share_state &= ~std::ifstream::failbit;
+  // clear old state and set new state
+  _share_ifiles[channel]->clear(share_state);
+
+  _share_ifiles[channel]->exceptions(std::ifstream::failbit);
+  _share_ofiles[channel]->exceptions(std::ofstream::failbit);
+
+  return 0;
+}
+
+void Input_Output_File::close_channel(unsigned int channel) {
+  *_outf << "Closing Channel " << channel << std::endl;
+  _private_gfp_ifiles.erase(channel);
+  _private_gfp_ofiles.erase(channel);
+
+  _public_gfp_ifiles.erase(channel);
+  _public_gfp_ofiles.erase(channel);
+
+  _public_int_ifiles.erase(channel);
+  _public_int_ofiles.erase(channel);
+
+  _share_ifiles.erase(channel);
+  _share_ofiles.erase(channel);
+}
+
+gfp Input_Output_File::private_input_gfp(unsigned int channel) {
+  word x;
+  *_private_gfp_ifiles[channel] >> x;
+  gfp y;
+  y.assign(x);
+  return y;
+}
+
+void Input_Output_File::private_output_gfp(
+    const gfp &output, unsigned int channel) {
+  *_private_gfp_ofiles[channel] << output << std::endl;
+}
+
+gfp Input_Output_File::public_input_gfp(unsigned int channel) {
+  word x;
+  *_public_gfp_ifiles[channel] >> x;
+  gfp y;
+  y.assign(x);
+  return y;
+
+  // Important to have this call in each version of public_input_gfp
+  Update_Checker(y, channel);
+
+  return y;
+}
+
+void Input_Output_File::public_output_gfp(
+    const gfp &output, unsigned int channel) {
+  *_public_gfp_ofiles[channel] << output << std::endl;
+}
+
+long Input_Output_File::public_input_int(unsigned int channel) {
+  long x;
+  *_public_int_ifiles[channel] >> x;
+  // Important to have this call in each version of public_input_gfp
+  Update_Checker(x, channel);
+
+  return x;
+}
+
+void Input_Output_File::public_output_int(
+    const long output, unsigned int channel) {
+  *_public_int_ofiles[channel] << output << std::endl;
+}
+
+void Input_Output_File::output_share(const Share &S, unsigned int channel) {
+  S.output(*_share_ofiles[channel], _human);
+}
+
+Share Input_Output_File::input_share(unsigned int channel) {
+  Share S;
+  S.input(*_share_ifiles[channel], _human);
+  return S;
+}
+
+void Input_Output_File::trigger(Schedule &schedule) {
+  std::cout << "Restart requested: Enter a number to proceed" << std::endl;
+  int i;
+  *_inpf >> i;
+
+  // Load new schedule file program streams, using the original
+  // program name
+  //
+  // Here you could define programatically what the new
+  // programs you want to run are, by directly editing the
+  // public variables in the schedule object.
+  unsigned int nthreads = schedule.Load_Programs();
+  if (schedule.max_n_threads() < nthreads) {
+    throw Processor_Error("Restart requires more threads, cannot do this");
+  }
+}
+
+void Input_Output_File::debug_output(const stringstream &ss) {
+  std::cout << ss.str() << std::flush;
+}
+
+void Input_Output_File::crash(unsigned int PC, unsigned int thread_num) {
+  std::cout <<
+    "Crashing in thread " << thread_num << "at PC value " << PC << std::endl;
+  throw crash_requested();
+}

--- a/src/Input_Output/Input_Output_File.h
+++ b/src/Input_Output/Input_Output_File.h
@@ -1,0 +1,80 @@
+/*
+Copyright (c) 2017, The University of Bristol, Senate House, Tyndall Avenue, Bristol, BS8 1TH, United Kingdom.
+Copyright (c) 2018, COSIC-KU Leuven, Kasteelpark Arenberg 10, bus 2452, B-3001 Leuven-Heverlee, Belgium.
+
+All rights reserved
+*/
+
+#pragma once
+
+/* A simple IO class which just uses standard
+ * input/output to communicate values
+ *
+ * Whereas share values are input/output using
+ * a stream, with either human or non-human form
+ */
+
+#include <fstream>
+#include <istream>
+#include <memory>
+#include <ostream>
+#include <string>
+#include <unordered_map>
+
+#include "Input_Output_Base.h"
+
+class Input_Output_File : public Input_Output_Base {
+ public:
+  Input_Output_File(
+      std::istream* ifs,
+      std::ostream* ofs,
+      bool human_type,
+      std::string& datadir,
+      int player_number) : Input_Output_Base(),
+                           _inpf{ifs},
+                           _outf{ofs},
+                           _human{human_type},
+                           _datadir{datadir},
+                           _player_number{player_number} {}
+
+  virtual long open_channel(unsigned int channel);
+  virtual void close_channel(unsigned int channel);
+
+  virtual gfp private_input_gfp(unsigned int channel);
+  virtual void private_output_gfp(const gfp &output, unsigned int channel);
+
+  virtual void public_output_gfp(const gfp &output, unsigned int channel);
+  virtual gfp public_input_gfp(unsigned int channel);
+
+  virtual void public_output_int(const long output, unsigned int channel);
+  virtual long public_input_int(unsigned int channel);
+
+  virtual void output_share(const Share &S, unsigned int channel);
+  virtual Share input_share(unsigned int channel);
+
+  virtual void trigger(Schedule &schedule);
+
+  virtual void debug_output(const stringstream &ss);
+
+  virtual void crash(unsigned int PC, unsigned int thread_num);
+
+ private:
+  std::istream* _inpf;
+  std::ostream* _outf;
+  // Only affects share output
+  bool _human;
+  std::string& _datadir;
+  int _player_number;
+
+  std::unordered_map<int, std::unique_ptr<ifstream>> _private_gfp_ifiles;
+  std::unordered_map<int, std::unique_ptr<ofstream>> _private_gfp_ofiles;
+  std::unordered_map<int, std::unique_ptr<ifstream>> _public_gfp_ifiles;
+  std::unordered_map<int, std::unique_ptr<ofstream>> _public_gfp_ofiles;
+  std::unordered_map<int, std::unique_ptr<ifstream>> _public_int_ifiles;
+  std::unordered_map<int, std::unique_ptr<ofstream>> _public_int_ofiles;
+  std::unordered_map<int, std::unique_ptr<ifstream>> _share_ifiles;
+  std::unordered_map<int, std::unique_ptr<ofstream>> _share_ofiles;
+
+  std::string open_channel_filename_helper(
+      unsigned int channel, const std::string& fn);
+};

--- a/src/Input_Output/Input_Output_Simple.h
+++ b/src/Input_Output/Input_Output_Simple.h
@@ -27,18 +27,13 @@ class Input_Output_Simple : public Input_Output_Base
   bool human; // Only affects share output
 
 public:
-  Input_Output_Simple()
-      : Input_Output_Base()
-  {
-    ;
-  }
-
-  void init(istream &ifs, ostream &ofs, bool human_type)
-  {
-    inpf= &ifs;
-    outf= &ofs;
-    human= human_type;
-  }
+  Input_Output_Simple(
+      std::istream* ifs,
+      std::ostream* ofs,
+      bool human_type) : Input_Output_Base(),
+                         inpf{ifs},
+                         outf{ofs},
+                         human{human_type} {}
 
   virtual long open_channel(unsigned int channel);
   virtual void close_channel(unsigned int channel);

--- a/src/Makefile
+++ b/src/Makefile
@@ -3,7 +3,7 @@ include ../CONFIG.mine
 
 CC = g++
 
-CFLAGS = -Wall -std=c++11 -pedantic -Wextra -g -pthread -I$(ROOT)/src -maes -mpclmul -msse4.1 -mavx -march=core2 $(FLAGS) $(OPT) -I$(OSSL)/include
+CFLAGS = -Wall -std=c++14 -pedantic -Wextra -g -pthread -I$(ROOT)/src -maes -mpclmul -msse4.1 -mavx -march=core2 $(FLAGS) $(OPT) -I$(OSSL)/include
 CPPFLAGS = $(CFLAGS) 
 LDLIBS = -L/$(OSSL)/lib -lm -lssl -lcrypto -lmpirxx -lmpir -lcryptopp $(LDFLAGS)
 

--- a/src/Player.cpp
+++ b/src/Player.cpp
@@ -21,6 +21,7 @@ using namespace std;
 #include "System/Networking.h"
 #include "System/RunTime.h"
 #include "config.h"
+#include "Input_Output/Input_Output_File.h"
 
 #include "Tools/ezOptionParser.h"
 using namespace ez;
@@ -75,6 +76,14 @@ int main(int argc, const char *argv[])
           "-verbose", // Flag token.
           "-v"        // Flag token.
   );
+  opt.add("", // Default.
+          0,   // Required?
+          1,   // Number of args expected.
+          0,   // Delimiter if expecting multiple args.
+          "Directory for player data files.\n",  // Help description.
+          "-datadir",
+          "-d" // Flag token.
+  );
   opt.add("empty", // Default.
           0,       // Required?
           1,       // Number of args expected.
@@ -127,6 +136,7 @@ int main(int argc, const char *argv[])
   int verbose, fhefacts;
   string progname;
   string memtype;
+  string datadir;
   unsigned int portnumbase;
 
   vector<string *> allArgs(opt.firstArgs);
@@ -176,6 +186,7 @@ int main(int argc, const char *argv[])
   portnumbase= (unsigned int) te;
   opt.get("-memory")->getString(memtype);
   opt.get("-verbose")->getInt(verbose);
+  opt.get("-datadir")->getString(datadir);
   opt.get("-fhefactories")->getInt(fhefacts);
   opt.get("-pns")->getInts(pns);
   opt.get("-min")->getInts(minimums);
@@ -365,8 +376,13 @@ int main(int argc, const char *argv[])
   // Here you configure the IO in the machine
   //  - This depends on what IO machinary you are using
   //  - Here we are just using the simple IO class
-  unique_ptr<Input_Output_Simple> io(new Input_Output_Simple);
-  io->init(cin, cout, true);
+  std::unique_ptr<Input_Output_Base> io;
+  if (opt.isSet("-datadir")) {
+    io = std::make_unique<Input_Output_File>(
+        &std::cin, &std::cout, true, datadir, my_number);
+  } else {
+    io = std::make_unique<Input_Output_Simple>(&std::cin, &std::cout, true);
+  }
   machine.Setup_IO(std::move(io));
 
   // Load the initial tapes for the first program into the schedule


### PR DESCRIPTION
This adds a utility file for I/O to handle input from a file. It adds the `-datadir` cmdline flag to Player.cpp. If this flag is defined, we will use

NOTE: This also makes use of `std::make_unique` which is a C++14 feature. I updated the Makefile to use `-std=c++14` to allow this. This is a more standard way of creating an object instead of using `new` with modern C++ code.

The default behavior is to continue using `Input_Output_Simple` when the `-d` flag is omitted.

This also addresses an issue in `Input_Output_Simple` of taking the address of a local reference, which is almost certainly not what you want to do. Instead, the constructor now takes raw pointers as parameters. There's likely an even better way of handling this, but for now, it's at least an improvement over taking the address of references.