### PR TITLE
fixed in Setup.cpp: was writing MKey files only when output stream is faulty

### DIFF
--- a/src/Setup.cpp
+++ b/src/Setup.cpp
@@ -482,15 +482,15 @@ void init_secret_sharing()
       if (outk.fail())
         {
           throw file_error(ss.str());
-          for (unsigned int j= 0; j < SD.nmacs; j++)
-            {
-              gfp aa;
-              aa.randomize(G);
-              outk << aa << " ";
-            }
-          outk << endl;
-          outk.close();
         }
+      for (unsigned int j= 0; j < SD.nmacs; j++)
+        {
+          gfp aa;
+          aa.randomize(G);
+          outk << aa << " ";
+        }
+      outk << endl;
+      outk.close();
 
       cout << "Finished setting up secret sharing. \nThe underlying MSP is...\n"
            << SD.M << endl;


### PR DESCRIPTION
I found this while double checking to what extents my previous PRs got incorporated. Setup.x would only write anything to the output streams of the `Data/MKey-i.key` files if said stream was faulty, caused by some scoping accident.

Also, it seems not all of my edits in PR #30 made it into the release, i.e., some of the consistency checks for file access I made are left out (namely a check for the output stream `outk` in `init_FHE` of `Setup.cpp`, line 92 and a similar check for the argument `s` in `GC/Circuit.cpp operator>>`, line 29). Is there a particular reason for that?