### PR TITLE
fix empty mac key bug

### DIFF
--- a/src/Setup.cpp
+++ b/src/Setup.cpp
@@ -482,6 +482,9 @@ void init_secret_sharing()
       if (outk.fail())
         {
           throw file_error(ss.str());
+        }
+      else
+        {
           for (unsigned int j= 0; j < SD.nmacs; j++)
             {
               gfp aa;


### PR DESCRIPTION
removes the mac key creation from the wrong control statement