### PR TITLE
Add force flag to remove

### DIFF
--- a/compile-new.sh
+++ b/compile-new.sh
@@ -32,9 +32,9 @@ do
   fi
 done
 
-rm $target/*.asm
-rm $target/*.bc
-rm $target/*.sch
+rm -f $target/*.asm
+rm -f $target/*.bc
+rm -f $target/*.sch
 # Do not add in -D flag automatically as this is too aggressive a remover of instructions
 printf "Running \n\t ./compile-mamba.py -A -n -r -u -s %s %s\n\n" $MAMBA_ARGS $target
 ./compile-mamba.py -A -n -r -u -s $MAMBA_ARGS $target || exit 1

--- a/compile-old.sh
+++ b/compile-old.sh
@@ -15,8 +15,8 @@ export PYTHONPATH=$ROOT:$PYTHONPATH
 
 shift $[OPTIND-1]
 
-rm $1/*.asm
-rm $1/*.bc
+rm -f $1/*.asm
+rm -f $1/*.bc
 printf "Running \n\t ./compile.py -s %s\n\n" $1
 ./compile-mamba.py -s $1 || exit 1
 


### PR DESCRIPTION
When the directory does not hold `asm`, `sch` and `bc` files the bash script fails